### PR TITLE
Add bigdecimal in apps

### DIFF
--- a/rails3/Gemfile
+++ b/rails3/Gemfile
@@ -7,6 +7,8 @@ gem 'jquery-rails'
 gem 'coderay', "~> 1.0.8"
 gem 'rdiscount'
 
+gem 'bigdecimal', '~> 1.4', '>= 1.4.4'
+
 group :assets do
   gem 'sass-rails'
   gem 'coffee-rails'

--- a/rails3/Gemfile.lock
+++ b/rails3/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     arel (3.0.3)
+    bigdecimal (1.4.4)
     builder (3.0.4)
     coderay (1.0.9)
     coffee-rails (3.2.2)
@@ -129,6 +130,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bigdecimal (~> 1.4, >= 1.4.4)
   coderay (~> 1.0.8)
   coffee-rails
   jquery-rails

--- a/rails4/Gemfile
+++ b/rails4/Gemfile
@@ -16,6 +16,8 @@ gem 'rdiscount'
 gem 'twitter-bootstrap-rails', '~>2.2.8'
 gem 'therubyracer', :platforms => :ruby
 
+gem 'bigdecimal', '~> 1.4', '>= 1.4.4'
+
 group :development, :test do
   gem 'byebug'
 end

--- a/rails4/Gemfile.lock
+++ b/rails4/Gemfile.lock
@@ -36,6 +36,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     arel (6.0.4)
+    bigdecimal (1.4.4)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.4)
@@ -160,6 +161,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bigdecimal (~> 1.4, >= 1.4.4)
   byebug
   coderay (~> 1.0.8)
   coffee-rails (~> 4.1.0)


### PR DESCRIPTION
rake command was not working in Rails 4 and Rails 3 using Ruby 2.7.1

> NoMethodError: undefined method `new' for BigDecimal:Class